### PR TITLE
Fix out-of-bounds click handling

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -50,6 +50,8 @@ function mouseClicked() {
   let bHeight = height / row;
   let bCol = int(mouseX / bWidth);
   let bRow = row - int(mouseY / bHeight) - 1;
+  if (bCol < 0 || bCol >= blocks.length) return;
+  if (bRow < 0 || bRow >= blocks[bCol].length) return;
 
   blocks[bCol][bRow].clicked();
   fall();


### PR DESCRIPTION
## Summary
- ignore clicks that fall outside the grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68468b88d5b4832ea6dc8e6f7f02020e