### PR TITLE
Add animation support for puzzle blocks

### DIFF
--- a/block.js
+++ b/block.js
@@ -8,17 +8,23 @@ class block {
     this.width = width / col;
     this.height = height / row;
 
-    this.x = this.width * (this.col);
+    this.x = this.width * this.col;
     this.y = height - this.height * (this.row + 1);
+
+    this.targetX = this.x;
+    this.targetY = this.y;
+    this.isMoving = false;
 
     this.poped = false;
     this.color = blockColors[int(random(0, blockColors.length))];
   }
 
   posUpdate() {
-
-    this.x = this.width * (this.col);
-    this.y = height - this.height * (this.row + 1);
+    this.targetX = this.width * this.col;
+    this.targetY = height - this.height * (this.row + 1);
+    if (abs(this.targetX - this.x) > 0.1 || abs(this.targetY - this.y) > 0.1) {
+      this.isMoving = true;
+    }
   }
 
   resize() {
@@ -98,6 +104,18 @@ class block {
     }
 
     if (blk != undefined) return blk;
+  }
+
+  update() {
+    if (this.isMoving) {
+      this.x = lerp(this.x, this.targetX, 0.25);
+      this.y = lerp(this.y, this.targetY, 0.25);
+      if (abs(this.x - this.targetX) < 0.5 && abs(this.y - this.targetY) < 0.5) {
+        this.x = this.targetX;
+        this.y = this.targetY;
+        this.isMoving = false;
+      }
+    }
   }
 
   display() {

--- a/sketch.js
+++ b/sketch.js
@@ -7,7 +7,6 @@ function setup() {
   canvasSize = 8 * min(windowWidth, windowHeight) / 10;
 
   createCanvas(canvasSize, canvasSize);
-  noLoop();
   for (let i = 0; i < col; i++) {
     blocks.push([]);
     for (let j = 0; j < row; j++) {
@@ -18,7 +17,15 @@ function setup() {
 
 function draw() {
   background(220);
-  for (let col of blocks) for (let blk of col) blk.display();
+  let moving = false;
+  for (let column of blocks) {
+    for (let blk of column) {
+      blk.update();
+      if (blk.isMoving) moving = true;
+      blk.display();
+    }
+  }
+  if (!moving) noLoop();
   checkGameClear();
 }
 
@@ -35,6 +42,7 @@ function fall() {
     blocks[i] = blocks[i].filter( function (x){ return x != undefined});
   }
   idxUpdate();
+  for (let column of blocks) for (let blk of column) blk.posUpdate();
 }
 
 function shiftLeft() {
@@ -56,7 +64,7 @@ function mouseClicked() {
   blocks[bCol][bRow].clicked();
   fall();
   shiftLeft();
-  redraw();
+  loop();
 }
 
 function windowResized() {


### PR DESCRIPTION
## Summary
- extend `block` class with motion properties and `update()`
- animate falling blocks and shifting left in `draw()`
- update blocks' target positions when grid changes
- start/stop the animation loop automatically

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68525d018e34832eb8e0cc79ac26a5c4